### PR TITLE
Fix timestamp update bug

### DIFF
--- a/NutriTechBackOffice.Domain/Entities/PlanAlimentacion.cs
+++ b/NutriTechBackOffice.Domain/Entities/PlanAlimentacion.cs
@@ -36,6 +36,6 @@ namespace NutriTechBackOffice.Domain.Entities
         public List<string> Colacion { get; set; }
 
         [FirestoreProperty, ServerTimestamp]
-        public Timestamp LastUpdated { get; set; }
+        public object LastUpdated { get; set; }
     }
 }

--- a/NutriTechBackOffice.Domain/Entities/PlanAsignacion.cs
+++ b/NutriTechBackOffice.Domain/Entities/PlanAsignacion.cs
@@ -15,7 +15,7 @@ namespace NutriTechBackOffice.Domain.Entities
         public string NotasAdicionales { get; set; }
 
         [FirestoreProperty, ServerTimestamp]
-        public Timestamp LastAssignment { get; set; }
+        public object LastAssignment { get; set; }
 
     }
 }

--- a/NutriTechBackOffice.Domain/Entities/User.cs
+++ b/NutriTechBackOffice.Domain/Entities/User.cs
@@ -30,6 +30,6 @@ namespace NutriTechBackOffice.Domain.Entities
         public string Telefono { get; set; }
 
         [FirestoreProperty, ServerTimestamp]
-        public Timestamp LastUpdated { get; set; }
+        public object LastUpdated { get; set; }
     }
 }

--- a/NutriTechBackOffice.Services/Planes/Commands/UpdatePlanCommandHandler.cs
+++ b/NutriTechBackOffice.Services/Planes/Commands/UpdatePlanCommandHandler.cs
@@ -63,9 +63,7 @@ namespace NutriTechBackOffice.Services.Planes.Commands
 
         private async Task<WriteResult> UpdatePlanInFirestoreDB(PlanAlimentacion plan)
         {
-            string jsonPlanes = JsonConvert.SerializeObject(plan);
-            var firestorePlanes = JsonConvert.DeserializeObject<ExpandoObject>(jsonPlanes);
-            return await this._PlansRef.Document(plan.Nombre).UpdateAsync(firestorePlanes);
+            return await this._PlansRef.Document(plan.Nombre).SetAsync(plan, SetOptions.MergeAll);
         }
     }
 }

--- a/NutriTechBackOffice.Services/Users/Commands/InserUserCommandHandler.cs
+++ b/NutriTechBackOffice.Services/Users/Commands/InserUserCommandHandler.cs
@@ -41,7 +41,6 @@ namespace NutriTechBackOffice.Services.Users.Commands
                         user = _mapper.Map<Nutricionista>(request.Usuario);
                         break;
                     default:
-                        //user = _mapper.Map<User>(request.Usuario);
                         break;
                 }
 

--- a/NutriTechBackOffice.Services/Users/Commands/UpdatePatientCommandHandler.cs
+++ b/NutriTechBackOffice.Services/Users/Commands/UpdatePatientCommandHandler.cs
@@ -63,9 +63,7 @@ namespace NutriTechBackOffice.Services.Users.Commands
 
         private async Task<WriteResult> UpdateUserInFirestoreDB(Paciente paciente)
         {
-            string jsonPaciente = JsonConvert.SerializeObject(paciente);
-            var firestorePaciente = JsonConvert.DeserializeObject<ExpandoObject>(jsonPaciente);
-            return await this._patientsRef.Document(paciente.Email).UpdateAsync(firestorePaciente);
+            return await this._patientsRef.Document(paciente.Email).SetAsync(paciente, SetOptions.MergeAll);
         }
     }
 }

--- a/NutriTechBackOffice.Services/Users/Commands/UpdateUserCommandHandler.cs
+++ b/NutriTechBackOffice.Services/Users/Commands/UpdateUserCommandHandler.cs
@@ -62,9 +62,7 @@ namespace NutriTechBackOffice.Services.Users.Commands
 
         private async Task<WriteResult> UpdateUserInFirestoreDB(User usuario)
         {
-            string jsonUsuarios = JsonConvert.SerializeObject(usuario);
-            var firestoreUsuarios = JsonConvert.DeserializeObject<ExpandoObject>(jsonUsuarios);
-            return await this._usersRef.Document(usuario.Email).UpdateAsync(firestoreUsuarios);
+            return await this._usersRef.Document(usuario.Email).SetAsync(usuario, SetOptions.MergeAll);
         }
     }
 }

--- a/NutriTechBackOffice/ClientApp/src/app/interfaces/paciente.ts
+++ b/NutriTechBackOffice/ClientApp/src/app/interfaces/paciente.ts
@@ -7,5 +7,4 @@ export interface Paciente extends User {
   medidaCintura: number;
   tipoAlimentacion: string;
   planAsignado: PlanAsignado;
-  lastAssignment: Date;
 }

--- a/NutriTechBackOffice/ClientApp/src/app/interfaces/plan-asignado.ts
+++ b/NutriTechBackOffice/ClientApp/src/app/interfaces/plan-asignado.ts
@@ -1,5 +1,5 @@
 export interface PlanAsignado {
   planAlimentacion: string;
   notasAdicionales: string;
-  lastAsignacion: Date;
+  lastAssignment: Date;
 }

--- a/NutriTechBackOffice/ClientApp/src/app/pages/asignacion-plan/asignacion-plan.component.ts
+++ b/NutriTechBackOffice/ClientApp/src/app/pages/asignacion-plan/asignacion-plan.component.ts
@@ -99,7 +99,7 @@ export class AsignacionPlanComponent implements OnInit {
     return {
       planAlimentacion: this.asignacionPlanForm.controls["planesAlimentacion"].value,
       notasAdicionales: this.asignacionPlanForm.controls["notasAdicionales"].value,
-      lastAsignacion: new Date(),
+      lastAssignment: null,
     };
   }
 

--- a/NutriTechBackOffice/ClientApp/src/app/pages/asignacion-plan/asignacion-plan.component.ts
+++ b/NutriTechBackOffice/ClientApp/src/app/pages/asignacion-plan/asignacion-plan.component.ts
@@ -123,7 +123,6 @@ export class AsignacionPlanComponent implements OnInit {
   }
 
   updatePacienteData(pacienteForm: PacienteForm) {
-    console.log(pacienteForm);
     this.disableFormWhileLoading();
 
     this.usersService.updatePaciente(this.pacienteSeleccionado.email, pacienteForm).subscribe
@@ -137,6 +136,7 @@ export class AsignacionPlanComponent implements OnInit {
         }
         ,
         (error) => {
+          console.log(error)
           this.dialog.open(PopUpComponent, { data: { title: "Oops!", message: "No se pudo asignar un plan al paciente." } });
         }
       );

--- a/NutriTechBackOffice/ClientApp/src/app/pages/login-form/login-form.component.css
+++ b/NutriTechBackOffice/ClientApp/src/app/pages/login-form/login-form.component.css
@@ -3,7 +3,7 @@
 }
 
 .login-card {
-  width:300px;
+  width: 300px;
   min-width: 120px;
   margin: 150px auto;
   align-items: center;
@@ -28,11 +28,16 @@
   margin-right: 20px;
 }
 
-.col:last-child {
-  margin-right: 0px;
-}
+  .col:last-child {
+    margin-right: 0px;
+  }
 
 .fondoform {
   background-image: url(../../../assets/img/35767-comida.jpg);
   background-size: 100%;
 }
+
+.password-eye:hover{
+  cursor: pointer;
+}
+

--- a/NutriTechBackOffice/ClientApp/src/app/pages/login-form/login-form.component.html
+++ b/NutriTechBackOffice/ClientApp/src/app/pages/login-form/login-form.component.html
@@ -24,7 +24,7 @@
         <div class="col">
           <mat-form-field class="full-width">
             <input matInput placeholder="Ingrese su contraseña" formControlName="password" [type]="hide? 'password' : 'text'" required>
-            <mat-icon matSuffix (click)="hide = !hide">{{hide ? 'visibility_off' : 'visibility'}}</mat-icon>
+            <mat-icon class="password-eye" matSuffix (click)="hide = !hide">{{hide ? 'visibility_off' : 'visibility'}}</mat-icon>
             <mat-error *ngIf="loginForm.controls['password'].hasError('required')">
               La contraseña es <strong>obligatoria</strong>
             </mat-error>

--- a/NutriTechBackOffice/ClientApp/src/app/pages/modificar-usuarios/modificar-usuarios.component.ts
+++ b/NutriTechBackOffice/ClientApp/src/app/pages/modificar-usuarios/modificar-usuarios.component.ts
@@ -204,10 +204,9 @@ export class ModificarUsuariosComponent implements OnInit {
       paciente.MedidaCintura = this.userModificacionForm.value['medidaCintura'];
       paciente.TipoAlimentacion = this.userModificacionForm.value['tipoAlimentacion'];
       paciente.PlanAsignado = this.pacienteModificar.planAsignado;
-      //Fix problem with generated ValueKind value in lastAssignment field
-      paciente.PlanAsignado.lastAssignment = null;
+      //Fijarse si el paciente ya tiene un plan asignado o no para que no rompa al asignar lastAssignment
+      if (paciente.PlanAsignado) { paciente.PlanAsignado.lastAssignment = null; }
 
-      console.log(paciente);
       return paciente;
 
     } catch (e) {

--- a/NutriTechBackOffice/ClientApp/src/app/pages/modificar-usuarios/modificar-usuarios.component.ts
+++ b/NutriTechBackOffice/ClientApp/src/app/pages/modificar-usuarios/modificar-usuarios.component.ts
@@ -1,7 +1,6 @@
 import { ActivatedRoute, Params, Route, Router } from '@angular/router';
 import { Component, OnInit } from '@angular/core';
 import { FormBuilder, Validators, FormControl } from '@angular/forms';
-import { Role } from '../../interfaces/role';
 import { User } from '../../interfaces/user';
 import { UserForm } from '../../interfaces/user-form';
 import { RolesService } from '../../services/roles.service';
@@ -46,7 +45,7 @@ export class ModificarUsuariosComponent implements OnInit {
   userModificacionForm = this.fb.group({
     firstName: [null, Validators.required],
     lastName: [null, Validators.required],
-    email: [{ value: '', disabled: true}],
+    email: [{ value: '', disabled: true }],
     password: [null, Validators.required],
     rol: [null, Validators.required],
     fechaNac: [null, Validators.required],
@@ -153,7 +152,7 @@ export class ModificarUsuariosComponent implements OnInit {
     if (this.userModificacionForm.valid) {
 
       if (this.rolParam == this.rolSeleccionado) {
-        
+
         this.updateWithoutRolSelection();
       } else {
         this.updateWithRolSelection();
@@ -167,7 +166,7 @@ export class ModificarUsuariosComponent implements OnInit {
     this.userModificacionForm.controls.lastName.setValue(userData.apellido);
     this.userModificacionForm.controls.email.setValue(userData.email);
     this.userModificacionForm.controls.password.setValue(userData.password);
-    this.userModificacionForm.controls.fechaNac.setValue(userData.fechaNacimiento? this.buildMomentForPicker(userData.fechaNacimiento) : null);
+    this.userModificacionForm.controls.fechaNac.setValue(userData.fechaNacimiento ? this.buildMomentForPicker(userData.fechaNacimiento) : null);
     this.userModificacionForm.controls.phoneNumber.setValue(userData.telefono);
     this.rolSeleccionado = userData.rol;
   }
@@ -188,7 +187,7 @@ export class ModificarUsuariosComponent implements OnInit {
     return _moment([year, month, day])
   }
 
-  private buildDateFromPicker():Date {
+  private buildDateFromPicker(): Date {
     let moment: Moment = this.userModificacionForm.value['fechaNac'];
     let stringDate = moment.format();
     return new Date(stringDate);
@@ -204,6 +203,11 @@ export class ModificarUsuariosComponent implements OnInit {
       paciente.Peso = this.userModificacionForm.value['peso'];
       paciente.MedidaCintura = this.userModificacionForm.value['medidaCintura'];
       paciente.TipoAlimentacion = this.userModificacionForm.value['tipoAlimentacion'];
+      paciente.PlanAsignado = this.pacienteModificar.planAsignado;
+      //Fix problem with generated ValueKind value in lastAssignment field
+      paciente.PlanAsignado.lastAssignment = null;
+
+      console.log(paciente);
       return paciente;
 
     } catch (e) {
@@ -250,7 +254,6 @@ export class ModificarUsuariosComponent implements OnInit {
 
   private updateUserFromPatient(email: string, paciente: PacienteForm) {
     this.disableFormWhileLoading();
-
     this.usersService.updateUserWithoutPatientData(email, paciente).subscribe(
       response => {
         let popupRef = this.dialog.open(PopUpComponent, { data: { title: "Listo!", message: "El usuario fue correctamente modificado." } });


### PR DESCRIPTION
Tomando como ejemplo la branch de Ivan, se corrigió el problema que había al actualizar un paciente/usuario/plan donde el campo timestamp se convertía a un formato de map en el documento y  se rompía todo. Principalmente se utilizó para el update el `SetAsync(object, SetOptions.MergeAll)` en vez del `UpdateAsync` y para todas las propiedades de los DTO con timestamp se modificó el tipo `Timestamp` a `object` _(esto último es así ya que arrojaba un error al querer deserializar el JSON con el form que viene desde el cliente a formato Timestamp)_.